### PR TITLE
FIX: el menú reacciona a inputs del joystick incluso cuando el launcher está fuera de foco

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -177,6 +177,11 @@ ui_end={
 "deadzone": 0.5,
 "events": [  ]
 }
+fullscreen={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":true,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":70,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [physics]
 

--- a/scripts/Global.gd
+++ b/scripts/Global.gd
@@ -18,7 +18,5 @@ var GAMES_PATH :String = PATH.plus_file("games")
 
 
 func _input(event: InputEvent) -> void:
-	if event is InputEventKey:
-		var kevent: InputEventKey = event
-		if kevent.alt and kevent.scancode == KEY_ENTER:
-			OS.window_fullscreen = !OS.window_fullscreen
+	if event.is_action("fullscreen") and event.is_pressed():
+		OS.window_fullscreen = !OS.window_fullscreen


### PR DESCRIPTION
La mayoría de los sistemas operativos redirigen los inputs del joystick a todas las aplicaciones que los acepten, independientemente de foco, esto con el teclado y mouse no pasa, dado que ahí sólo se envían a la aplicación enfocada.

Este pull request resuelve la situación que se da cuando con el joystick se ejecuta un juego desde el launcher, y luego dentro del juego se aprieta START o X, lo cual produce que el launcher vuelva a ejecutar el juego que tiene seleccionado.

Además ahora las ejecuciones se hacen sin pausar el launcher, ya que esto produciría que cuando el juego se cierre el launcher ejecute todos los comandos que no pudo interpretar cuando estaba pausado y que ahora que está de nuevo en foco pasaría a ejecutar