### PR TITLE
input mapping

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -182,6 +182,16 @@ fullscreen={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":true,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":70,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
+quitA={
+"deadzone": 0.5,
+"events": [ Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":10,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+quitB={
+"deadzone": 0.5,
+"events": [ Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
 
 [physics]
 

--- a/project.godot
+++ b/project.godot
@@ -108,6 +108,7 @@ ui_accept={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 ui_select={

--- a/project.godot
+++ b/project.godot
@@ -146,7 +146,7 @@ ui_right={
  ]
 }
 ui_up={
-"deadzone": 0.5,
+"deadzone": 0.95,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
@@ -154,7 +154,7 @@ ui_up={
  ]
 }
 ui_down={
-"deadzone": 0.5,
+"deadzone": 0.95,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)

--- a/scenes/GameSelection/GameSelection.gd
+++ b/scenes/GameSelection/GameSelection.gd
@@ -2,6 +2,8 @@ extends UIState
 onready var game_info_display: Control = $"%game_info_display"
 onready var item_list: ItemList = $"%ItemList"
 
+signal running_program(pid)
+
 var game_list := []
 var selected_item = -1
 func _enter_state():
@@ -57,7 +59,8 @@ func _on_item_activated(index: int):
 	_execute(info.get_executable_path())
 
 func _execute(path):
-	OS.execute(path, PoolStringArray(), false)
+	var pid = OS.execute(path, PoolStringArray(), false)
+	emit_signal("running_program", pid)
 	pass
 
 

--- a/scenes/GameSelection/GameSelection.tscn
+++ b/scenes/GameSelection/GameSelection.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://scenes/GameSelection/GameSelection.gd" type="Script" id=1]
 [ext_resource path="res://assets/res/global_theme.tres" type="Theme" id=2]
 [ext_resource path="res://icon.png" type="Texture" id=3]
 [ext_resource path="res://assets/res/fonts/font_default_48px.tres" type="DynamicFont" id=4]
 [ext_resource path="res://scenes/GameSelection/game_info_display.gd" type="Script" id=5]
+[ext_resource path="res://scenes/GameSelection/quitter.tscn" type="PackedScene" id=6]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.435294, 0.258824, 0.662745, 1 )
@@ -207,3 +208,5 @@ margin_top = 1048.0
 margin_right = 1920.0
 margin_bottom = 1080.0
 rect_min_size = Vector2( 0, 32 )
+
+[node name="quitter" parent="." instance=ExtResource( 6 )]

--- a/scenes/GameSelection/quitter.gd
+++ b/scenes/GameSelection/quitter.gd
@@ -1,23 +1,22 @@
 extends Node
 
+const NO_PROGRAM = -1
+
 onready var quit_timer: Timer = $"%quit_timer"
-var running_program
+var running_program_pid = NO_PROGRAM
 
 func _quit_focused_window():
-	if running_program == -1:
+	if running_program_pid == NO_PROGRAM:
 		return
-	OS.kill(running_program)
-	running_program = -1
+	if OS.is_process_running(running_program_pid):
+		OS.kill(running_program_pid)
+	running_program_pid = NO_PROGRAM
 	pass
 func _on_running_program(pid):
-	running_program = pid
+	running_program_pid = pid
 
 func _process(delta: float) -> void:
-	if (
-		!OS.is_window_focused() and 
-		Input.is_action_pressed("quitA") and 
-		Input.is_action_pressed("quitB")
-	):
+	if Input.is_action_pressed("quitA") and Input.is_action_pressed("quitB"):
 		if quit_timer.is_stopped():
 			quit_timer.start()
 	else:

--- a/scenes/GameSelection/quitter.gd
+++ b/scenes/GameSelection/quitter.gd
@@ -1,0 +1,28 @@
+extends Node
+
+onready var quit_timer: Timer = $"%quit_timer"
+var running_program
+
+func _quit_focused_window():
+	if running_program == -1:
+		return
+	OS.kill(running_program)
+	running_program = -1
+	pass
+func _on_running_program(pid):
+	running_program = pid
+
+func _process(delta: float) -> void:
+	if (
+		!OS.is_window_focused() and 
+		Input.is_action_pressed("quitA") and 
+		Input.is_action_pressed("quitB")
+	):
+		if quit_timer.is_stopped():
+			quit_timer.start()
+	else:
+		quit_timer.stop()
+
+func _ready() -> void:
+	quit_timer.connect("timeout", self, "_quit_focused_window")
+	owner.connect("running_program",self,"_on_running_program")

--- a/scenes/GameSelection/quitter.tscn
+++ b/scenes/GameSelection/quitter.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scenes/GameSelection/quitter.gd" type="Script" id=1]
+
+[node name="quitter" type="Node"]
+script = ExtResource( 1 )
+
+[node name="quit_timer" type="Timer" parent="."]
+unique_name_in_owner = true
+process_mode = 0
+wait_time = 3.0
+one_shot = true


### PR DESCRIPTION
closes [#5](https://github.com/PlayJamDevs/Play-Jam-Launcher-2/issues/5)

Cuando se corre un programa desde el launcher, se guarda el PID, si el usuario mantiene apretados los botones SELECT + START por 3 segundos en el joystick, se mata el proceso correspondiente a dicho PID. Esto funciona debido a que el launcher sigue escuchando eventos del joystick cuando está fuera de foco (debido a que así funcionan los eventos de joystick en la mayoría de los sistemas operativos, a diferencia de los teclados)

![Peek 2023-06-25 14-52](https://github.com/PlayJamDevs/Play-Jam-Launcher-2/assets/8540266/e1528d6c-3138-4692-a4d0-9da868f1a80d)
