### PR TITLE
achicar fuente y alargar link

### DIFF
--- a/scenes/GameSelection/GameSelection.tscn
+++ b/scenes/GameSelection/GameSelection.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://scenes/GameSelection/GameSelection.gd" type="Script" id=1]
 [ext_resource path="res://assets/res/global_theme_v2.tres" type="Theme" id=2]
 [ext_resource path="res://icon.png" type="Texture" id=3]
-[ext_resource path="res://assets/res/fonts/font_default_48px.tres" type="DynamicFont" id=4]
+[ext_resource path="res://assets/res/fonts/font_default.tres" type="DynamicFont" id=4]
 [ext_resource path="res://scenes/GameSelection/game_info_display.gd" type="Script" id=5]
 [ext_resource path="res://scenes/GameSelection/quitter.tscn" type="PackedScene" id=6]
 
@@ -112,11 +112,11 @@ rect_min_size = Vector2( 0, 64 )
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer/game_info_display/VBoxContainer"]
 margin_top = 68.0
 margin_right = 1200.0
-margin_bottom = 312.0
+margin_bottom = 377.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/game_info_display/VBoxContainer/HBoxContainer"]
 margin_right = 956.0
-margin_bottom = 244.0
+margin_bottom = 309.0
 rect_min_size = Vector2( 860, 0 )
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -154,38 +154,40 @@ clip_text = true
 unique_name_in_owner = true
 margin_top = 186.0
 margin_right = 956.0
-margin_bottom = 244.0
-rect_min_size = Vector2( 0, 58 )
+margin_bottom = 309.0
+rect_min_size = Vector2( 0, 123 )
 custom_fonts/font = ExtResource( 4 )
 text = "Link:"
-clip_text = true
+autowrap = true
+percent_visible = -0.2
+max_lines_visible = 3
 
 [node name="CenterContainer" type="CenterContainer" parent="VBoxContainer/HBoxContainer/game_info_display/VBoxContainer/HBoxContainer"]
 margin_left = 960.0
 margin_right = 1200.0
-margin_bottom = 244.0
+margin_bottom = 309.0
 rect_min_size = Vector2( 240, 240 )
 
 [node name="QR" type="TextureRect" parent="VBoxContainer/HBoxContainer/game_info_display/VBoxContainer/HBoxContainer/CenterContainer"]
 unique_name_in_owner = true
-margin_top = 2.0
+margin_top = 34.0
 margin_right = 240.0
-margin_bottom = 242.0
+margin_bottom = 274.0
 rect_min_size = Vector2( 240, 240 )
 texture = ExtResource( 3 )
 stretch_mode = 5
 
 [node name="vertical_space2" type="Control" parent="VBoxContainer/HBoxContainer/game_info_display/VBoxContainer"]
-margin_top = 316.0
+margin_top = 381.0
 margin_right = 1200.0
-margin_bottom = 348.0
+margin_bottom = 413.0
 rect_min_size = Vector2( 0, 32 )
 
 [node name="cover" type="TextureRect" parent="VBoxContainer/HBoxContainer/game_info_display/VBoxContainer"]
 unique_name_in_owner = true
-margin_top = 352.0
+margin_top = 417.0
 margin_right = 1200.0
-margin_bottom = 702.0
+margin_bottom = 767.0
 rect_min_size = Vector2( 1200, 350 )
 size_flags_horizontal = 0
 size_flags_vertical = 0
@@ -193,14 +195,14 @@ expand = true
 stretch_mode = 7
 
 [node name="vertical_space3" type="Control" parent="VBoxContainer/HBoxContainer/game_info_display/VBoxContainer"]
-margin_top = 706.0
+margin_top = 771.0
 margin_right = 1200.0
-margin_bottom = 738.0
+margin_bottom = 803.0
 rect_min_size = Vector2( 0, 32 )
 
 [node name="description" type="Label" parent="VBoxContainer/HBoxContainer/game_info_display/VBoxContainer"]
 unique_name_in_owner = true
-margin_top = 742.0
+margin_top = 807.0
 margin_right = 1200.0
 margin_bottom = 1044.0
 size_flags_vertical = 7

--- a/scenes/GameSelection/game_info_display.gd
+++ b/scenes/GameSelection/game_info_display.gd
@@ -14,11 +14,16 @@ const MAX_QR_SIZE = 240
 static func entry_text(entry, value):
 	return "%s: %s" % [entry, value if value else "???"]
 
+# non breaking space (igual desgraciadamente no se detecta como espacio)
+# y se ve todo junto
+static func entry_text_no_break_space(entry, value):
+	return "%s: %s" % [entry, value if value else "???"]
+
 func display_game(info: GameData):
 	title.text = entry_text("Título", info.title)
 	year.text = entry_text("Año", info.year)
 	author.text = entry_text("Autor", info.author)
-	link.text = entry_text("Link", info.link)
+	link.text = entry_text_no_break_space("Link", info.link)
 	description.text = entry_text("Descripción", info.description)
 	
 	cover.texture = info.cover


### PR DESCRIPTION
closes [#14](https://github.com/PlayJamDevs/Play-Jam-Launcher-2/issues/14)

Al final se limita el link a 3 líneas, se intentó que el espacio entre "Link:" y el link sea non-breaking para que no se desperdicie una linea entera en separarlos pero godot (o la fuente, no sé) no lo detecta como espacio, entonces queda todo junto

![image](https://github.com/PlayJamDevs/Play-Jam-Launcher-2/assets/8540266/98f47f75-bf53-449c-a776-dd58e870eaa3)
