### PR TITLE
Links clickeables y accesibles

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -195,6 +195,11 @@ quitB={
 "events": [ Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
+visit_link={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777245,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [physics]
 

--- a/project.godot
+++ b/project.godot
@@ -121,6 +121,7 @@ ui_cancel={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":3,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":2,"pressed":false,"doubleclick":false,"script":null)
  ]
 }
 ui_focus_next={

--- a/scenes/Categories.gd
+++ b/scenes/Categories.gd
@@ -24,7 +24,7 @@ var selected
 func _unhandled_input(event : InputEvent):
 	
 	if event.is_action_pressed("ui_accept"):
-		open_games_folder(folders[selected_idx])
+		goto_games()
 		return
 	
 	var direction = (event.get_action_strength("ui_right") - event.get_action_strength("ui_left"))
@@ -38,6 +38,9 @@ func _unhandled_input(event : InputEvent):
 	
 	update_selected()
 
+func goto_games():
+	open_games_folder(folders[selected_idx])
+
 func update_selected():
 	selected = n_PanelC.get_child(selected_idx)
 	for p in n_PanelC.get_children():
@@ -49,6 +52,21 @@ func update_selected():
 
 func _ready():
 	._ready()
+	update_selected()
+	var i = 0
+	for p in n_PanelC.get_children():
+		p.connect("gui_input",self,"_panel_gui_input",[i])
+		p.connect("mouse_entered",self,"_panel_mouse_entered",[i])
+		i+=1
+
+func _panel_gui_input(event:InputEvent, index:int):
+	if Global.is_click(event):
+		selected_idx = index
+		goto_games()
+		
+
+func _panel_mouse_entered(index:int):
+	selected_idx = index
 	update_selected()
 
 func open_games_folder(folder_name):

--- a/scenes/Categories.gd
+++ b/scenes/Categories.gd
@@ -60,7 +60,7 @@ func _ready():
 		i+=1
 
 func _panel_gui_input(event:InputEvent, index:int):
-	if Global.is_click(event):
+	if Global.is_left_click(event):
 		selected_idx = index
 		goto_games()
 		

--- a/scenes/Categories/Categories.tscn
+++ b/scenes/Categories/Categories.tscn
@@ -128,10 +128,12 @@ modulate = Color( 0.364706, 0, 0.529412, 0.470588 )
 show_behind_parent = true
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 1
 
 [node name="Label" type="Label" parent="HBoxContainer/Panel2"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 1
 text = "INDIE
 GAMES"
 align = 1
@@ -154,10 +156,12 @@ modulate = Color( 0.364706, 0, 0.529412, 0.470588 )
 show_behind_parent = true
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 1
 
 [node name="Label" type="Label" parent="HBoxContainer/Panel3"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 1
 text = "GAME
 JAMS"
 align = 1

--- a/scenes/GameSelection/GameSelection.gd
+++ b/scenes/GameSelection/GameSelection.gd
@@ -33,7 +33,12 @@ func _input(event: InputEvent) -> void:
 		return
 	if has_program_running():
 		return
-
+	if event.is_action_pressed("visit_link"):
+		if !game_list.empty():
+			var link = game_list[selected_item].link
+			if link:
+				OS.shell_open(link)
+	
 	if (
 		can_abort and 
 		(

--- a/scenes/GameSelection/GameSelection.gd
+++ b/scenes/GameSelection/GameSelection.gd
@@ -29,6 +29,9 @@ func _on_item_selected(index: int):
 	selected_item = index
 	
 func _input(event: InputEvent) -> void:
+	handle_input(event)
+	
+func handle_input(event):
 	if !OS.is_window_focused():
 		return
 	if has_program_running():

--- a/scenes/GameSelection/GameSelection.gd
+++ b/scenes/GameSelection/GameSelection.gd
@@ -34,8 +34,16 @@ func _input(event: InputEvent) -> void:
 	if has_program_running():
 		return
 
-	if can_abort and (Global.is_click(event) or event.is_action_pressed("ui_accept")):
+	if (
+		can_abort and 
+		(
+			Global.is_left_click(event) or 
+			Global.is_right_click(event) or 
+			event.is_action_pressed("ui_accept")
+		)
+	):
 		emit_signal("execution_prepare_finished", false)
+		return
 		
 	if event.is_action_pressed("ui_accept"):
 		if !preparing_execution:

--- a/scenes/GameSelection/GameSelection.gd
+++ b/scenes/GameSelection/GameSelection.gd
@@ -28,17 +28,19 @@ func _on_item_selected(index: int):
 	game_info_display.display_game(game_list[index])
 	selected_item = index
 	
-
-func _unhandled_input(event: InputEvent) -> void:
+func _input(event: InputEvent) -> void:
 	if !OS.is_window_focused():
 		return
 	if has_program_running():
 		return
+
+	if can_abort and (Global.is_click(event) or event.is_action_pressed("ui_accept")):
+		emit_signal("execution_prepare_finished", false)
+		
 	if event.is_action_pressed("ui_accept"):
 		if !preparing_execution:
 			activate()
-		if can_abort:
-			emit_signal("execution_prepare_finished", false)
+			
 		
 	if preparing_execution:
 		return

--- a/scenes/GameSelection/GameSelection.tscn
+++ b/scenes/GameSelection/GameSelection.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://scenes/GameSelection/GameSelection.gd" type="Script" id=1]
 [ext_resource path="res://assets/res/global_theme_v2.tres" type="Theme" id=2]
@@ -9,6 +9,7 @@
 [ext_resource path="res://scenes/GameSelection/echo_dpad_simulator.tscn" type="PackedScene" id=7]
 [ext_resource path="res://assets/fonts/Barlow-Medium.ttf" type="DynamicFontData" id=8]
 [ext_resource path="res://scenes/GameSelection/music_handler.gd" type="Script" id=9]
+[ext_resource path="res://scenes/GameSelection/link.gd" type="Script" id=10]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.435294, 0.258824, 0.662745, 0.588235 )
@@ -295,16 +296,15 @@ custom_fonts/font = ExtResource( 4 )
 text = "Autor:"
 clip_text = true
 
-[node name="link" type="Label" parent="VBoxContainer/HBoxContainer/game_info_display/VBoxContainer/HBoxContainer/VBoxContainer"]
+[node name="link" type="RichTextLabel" parent="VBoxContainer/HBoxContainer/game_info_display/VBoxContainer/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 margin_top = 186.0
 margin_right = 956.0
 margin_bottom = 309.0
 rect_min_size = Vector2( 0, 123 )
-custom_fonts/font = ExtResource( 4 )
-text = "Link:"
-autowrap = true
-max_lines_visible = 3
+mouse_filter = 1
+bbcode_enabled = true
+script = ExtResource( 10 )
 
 [node name="CenterContainer" type="CenterContainer" parent="VBoxContainer/HBoxContainer/game_info_display/VBoxContainer/HBoxContainer"]
 margin_left = 960.0
@@ -420,7 +420,7 @@ autowrap = true
 anchor_right = 1.0
 margin_bottom = 39.0
 custom_fonts/font = ExtResource( 4 )
-text = "(para salir de un juego presionar START + SELECT por 2 segundos)"
+text = "(Para salir de un juego presionar START + SELECT por 2 segundos. Presioná F2 para visitar el link del juego)"
 align = 1
 
 [node name="music_handler" type="Node" parent="."]

--- a/scenes/GameSelection/GameSelection.tscn
+++ b/scenes/GameSelection/GameSelection.tscn
@@ -380,6 +380,7 @@ anims/launch = SubResource( 3 )
 visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 1
 color = Color( 0, 0, 0, 0 )
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="ColorRect2"]
@@ -392,6 +393,7 @@ margin_right = 1920.0
 margin_bottom = 480.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 1
 custom_fonts/font = SubResource( 4 )
 text = "3"
 align = 1
@@ -403,6 +405,7 @@ margin_right = 1920.0
 margin_bottom = 871.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 1
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_constants/shadow_offset_x = 5
 custom_constants/shadow_offset_y = 5

--- a/scenes/GameSelection/echo_dpad_simulator.gd
+++ b/scenes/GameSelection/echo_dpad_simulator.gd
@@ -23,7 +23,7 @@ func _process(delta: float) -> void:
 			e.action = "ui_up"
 		e.pressed = true
 		e.strength = 1.0
-		owner._unhandled_input(e)
+		owner.handle_input(e)
 		echo_repeat_timer.start()
 
 func _ready() -> void:

--- a/scenes/GameSelection/game_info_display.gd
+++ b/scenes/GameSelection/game_info_display.gd
@@ -3,7 +3,7 @@ extends Control
 onready var title: Label = $"%title"
 onready var year: Label = $"%year"
 onready var author: Label = $"%author"
-onready var link: Label = $"%link"
+onready var link: RichTextLabel = $"%link"
 onready var qr: TextureRect = $"%QR"
 onready var cover: TextureRect = $"%cover"
 onready var description: Label = $"%description"
@@ -23,7 +23,8 @@ func display_game(info: GameData):
 	title.text = entry_text("Título", info.title)
 	year.text = entry_text("Año", info.year)
 	author.text = entry_text("Autor", info.author)
-	link.text = entry_text_no_break_space("Link", info.link)
+	link.bbcode_text = "Link:[url]%s[/url]" % info.link
+	link.url = info.link
 	description.text = entry_text("Descripción", info.description)
 	
 	cover.texture = info.cover

--- a/scenes/GameSelection/link.gd
+++ b/scenes/GameSelection/link.gd
@@ -1,0 +1,10 @@
+extends RichTextLabel
+
+var url = ""
+var just_pressed := false
+
+func _ready() -> void:
+	connect("meta_clicked", self, "_pressed")
+
+func _pressed(what:String):
+	OS.shell_open(url)

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=45 format=2]
+[gd_scene load_steps=46 format=2]
 
 [ext_resource path="res://assets/res/shader_retro.tres" type="Material" id=1]
 [ext_resource path="res://assets/playjam_logo_transparent.png" type="Texture" id=2]
@@ -947,14 +947,17 @@ auto_advance = true
 [sub_resource type="AnimationNodeStateMachineTransition" id=13]
 advance_condition = "exit"
 
+[sub_resource type="AnimationNodeStateMachineTransition" id=44]
+advance_condition = "exit"
+
 [sub_resource type="AnimationNodeStateMachine" id=14]
 states/intro/node = SubResource( 9 )
-states/intro/position = Vector2( 317, 48 )
+states/intro/position = Vector2( 373, 131 )
 states/intro_exit/node = SubResource( 10 )
-states/intro_exit/position = Vector2( 721, 48 )
+states/intro_exit/position = Vector2( 695, 131 )
 states/intro_idle/node = SubResource( 11 )
 states/intro_idle/position = Vector2( 508, 48 )
-transitions = [ "intro", "intro_idle", SubResource( 12 ), "intro_idle", "intro_exit", SubResource( 13 ) ]
+transitions = [ "intro", "intro_idle", SubResource( 12 ), "intro_idle", "intro_exit", SubResource( 13 ), "intro", "intro_exit", SubResource( 44 ) ]
 start_node = "intro"
 end_node = "intro_exit"
 graph_offset = Vector2( -50.0661, 0 )
@@ -1037,6 +1040,7 @@ valign = 1
 [node name="FadeBlack" type="ColorRect" parent="UI/Intro"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 1
 color = Color( 0, 0, 0, 1 )
 
 [node name="Categories" parent="UI" instance=ExtResource( 7 )]

--- a/scripts/Global.gd
+++ b/scripts/Global.gd
@@ -20,3 +20,10 @@ var GAMES_PATH :String = PATH.plus_file("games")
 func _input(event: InputEvent) -> void:
 	if event.is_action("fullscreen") and event.is_pressed():
 		OS.window_fullscreen = !OS.window_fullscreen
+
+func is_click(event: InputEvent) -> bool:
+	return (
+		event is InputEventMouseButton and 
+		event.is_pressed() and 
+		(event as InputEventMouseButton).button_index == BUTTON_LEFT
+	)

--- a/scripts/Global.gd
+++ b/scripts/Global.gd
@@ -21,9 +21,13 @@ func _input(event: InputEvent) -> void:
 	if event.is_action("fullscreen") and event.is_pressed():
 		OS.window_fullscreen = !OS.window_fullscreen
 
-func is_click(event: InputEvent) -> bool:
+func is_left_click(event: InputEvent) -> bool:
+	return is_click(event, BUTTON_LEFT)
+func is_right_click(event: InputEvent) -> bool:
+	return is_click(event, BUTTON_RIGHT)
+func is_click(event:InputEvent, button:int)->bool:
 	return (
 		event is InputEventMouseButton and 
 		event.is_pressed() and 
-		(event as InputEventMouseButton).button_index == BUTTON_LEFT
+		(event as InputEventMouseButton).button_index == button
 	)

--- a/scripts/states/Intro.gd
+++ b/scripts/states/Intro.gd
@@ -10,11 +10,11 @@ func _unhandled_input(event : InputEvent):
 	
 	if (
 		event is InputEventKey or
-		event is InputEventJoypadButton or Global.is_click(event)
+		event is InputEventJoypadButton or Global.is_left_click(event)
 	) and event.pressed:
 		exit()
 func _gui_input(event: InputEvent) -> void:
-	if Global.is_click(event):
+	if Global.is_left_click(event):
 		exit()
 
 func exit():

--- a/scripts/states/Intro.gd
+++ b/scripts/states/Intro.gd
@@ -10,7 +10,12 @@ func _unhandled_input(event : InputEvent):
 	
 	if (
 		event is InputEventKey or
-		event is InputEventJoypadButton
+		event is InputEventJoypadButton or Global.is_click(event)
 	) and event.pressed:
-		
-		n_AnimTree["parameters/Intro/conditions/exit"] = true
+		exit()
+func _gui_input(event: InputEvent) -> void:
+	if Global.is_click(event):
+		exit()
+
+func exit():
+	n_AnimTree["parameters/Intro/conditions/exit"] = true

--- a/scripts/states/UIState.gd
+++ b/scripts/states/UIState.gd
@@ -6,10 +6,12 @@ onready var n_AnimTree : AnimationTree = get_tree().get_nodes_in_group("AnimTree
 
 func enter_state() -> void:
 	set_process_unhandled_input(true)
+	set_process_input(true)
 	_enter_state()
 
 func exit_state() -> void:
 	set_process_unhandled_input(false)
+	set_process_input(false)
 	_exit_state()
 
 func _ready() -> void:


### PR DESCRIPTION
closes #26 
NOTA: al pasar de Label a RichTextLabel para el link, y al implementarlo como un [url] en BBCode, ahora inevitablemente se rompe la línea cuando el link es muy largo, haciendo que la primera línea sea solo "Link:", si esto es un problema lo podemos ver por ejemplo, haciendo al scroll visible para ese RichTextLabel