### PR TITLE
Filtrar nombres de archivos reservados

### DIFF
--- a/scenes/GameSelection/game_data.gd
+++ b/scenes/GameSelection/game_data.gd
@@ -78,6 +78,7 @@ func as_dictionary():
 		year = year,
 		author = author,
 		link = link,
-		description = description
+		description = description,
+		executable_name = executable_name
 	}
 	


### PR DESCRIPTION
closes #29 

Funcionamiento:
- se ignoran "UnityCrashHandler32.exe", "UnityCrashHandler64.exe" a menos que sean los únicos ejecutables
- se agrega un campo al json, "executable_name" el cual fuerza el ejecutable a ser el especificado, **a menos** que el mismo no exista o no corresponda a un ejecutable, en cuyo caso se ignora.

ejemplo:
teniendo en el info.json
"executable_name": "hola.exe"
- si existe en la carpeta un archivo "hola.exe", que sea ejecutable, se tomará al mismo como el ejecutable, 
- de no existir se buscará el primer ejecutable que no sea "UnityCrashHandler32.exe", "UnityCrashHandler64.exe"
- de no existir se tomará uno de los archivos blacklisteados, en orden alfabético descendiente
- de no existir se asume que no hay ejecutable